### PR TITLE
Consider normal and refund operations separately

### DIFF
--- a/account_tax_balance/__openerp__.py
+++ b/account_tax_balance/__openerp__.py
@@ -19,6 +19,7 @@
     ],
     "data": [
         "wizard/open_tax_balances_view.xml",
+        "views/account_move_view.xml",
         "views/account_tax_view.xml",
     ],
     "images": [

--- a/account_tax_balance/__openerp__.py
+++ b/account_tax_balance/__openerp__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # © 2016 Lorenzo Battistini - Agile Business Group
+# © 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Tax Balance",
@@ -7,7 +8,7 @@
     "version": "9.0.1.0.0",
     "category": "Accounting & Finance",
     "website": "https://www.agilebg.com/",
-    "author": "Agile Business Group, Therp BV, "
+    "author": "Agile Business Group, Therp BV, Tecnativa, "
               "Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,

--- a/account_tax_balance/i18n/es.po
+++ b/account_tax_balance/i18n/es.po
@@ -1,0 +1,261 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_tax_balance
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-10-21 15:30+0000\n"
+"PO-Revision-Date: 2016-10-21 15:30+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_tax_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.view_tax_search_balance
+msgid "Account"
+msgstr "Cuenta"
+
+#. module: account_tax_balance
+#: model:ir.model,name:account_tax_balance.model_account_move
+msgid "Account Entry"
+msgstr "Asiento contable"
+
+#. module: account_tax_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.view_tax_search_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.view_tax_tree_balance
+msgid "Account Tax"
+msgstr "Cuenta de impuesto"
+
+#. module: account_tax_balance
+#: selection:wizard.open.tax.balances,target_move:0
+msgid "All Entries"
+msgstr "Todos los asientos"
+
+#. module: account_tax_balance
+#: selection:wizard.open.tax.balances,target_move:0
+msgid "All Posted Entries"
+msgstr "Todos los asientos asentados"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_account_tax_balance_regular
+msgid "Balance"
+msgstr "Cuota"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_account_tax_balance_refund
+msgid "Balance Refund"
+msgstr "Cuota devoluciones"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_account_tax_base_balance_regular
+msgid "Base Balance"
+msgstr "Base imponible"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_account_tax_base_balance_refund
+msgid "Base Balance Refund"
+msgstr "Base devoluciones"
+
+#. module: account_tax_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.view_tax_tree_balance
+msgid "Base Total"
+msgstr "Base total"
+
+#. module: account_tax_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.wizard_open_tax_balances
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_wizard_open_tax_balances_company_id
+msgid "Company"
+msgstr "Compañía"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_wizard_open_tax_balances_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_wizard_open_tax_balances_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_wizard_open_tax_balances_date_range_id
+msgid "Date range"
+msgstr "Periodo"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_wizard_open_tax_balances_display_name
+msgid "Display Name"
+msgstr "Nombre a mostrar"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_wizard_open_tax_balances_from_date
+msgid "From date"
+msgstr "Desde"
+
+#. module: account_tax_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.view_tax_search_balance
+msgid "Group By"
+msgstr "Agrupar por"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_wizard_open_tax_balances_id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_wizard_open_tax_balances___last_update
+msgid "Last Modified on"
+msgstr "Última modificación en"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_wizard_open_tax_balances_write_uid
+msgid "Last Updated by"
+msgstr "Última modificación por"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_wizard_open_tax_balances_write_date
+msgid "Last Updated on"
+msgstr "Última actualización en"
+
+#. module: account_tax_balance
+#: selection:account.move,move_type:0
+msgid "Liquidity"
+msgstr "Liquidez"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_account_move_move_type
+msgid "Move type"
+msgstr "Tipo de operación"
+
+#. module: account_tax_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.wizard_open_tax_balances
+msgid "Open Taxes"
+msgstr "Ver impuestos"
+
+#. module: account_tax_balance
+#: selection:account.move,move_type:0
+msgid "Other"
+msgstr "Otro"
+
+#. module: account_tax_balance
+#: selection:account.move,move_type:0
+msgid "Payable"
+msgstr "A pagar"
+
+#. module: account_tax_balance
+#: selection:account.move,move_type:0
+msgid "Payable refund"
+msgstr "Devoluciones a cobrar"
+
+#. module: account_tax_balance
+#: selection:account.move,move_type:0
+msgid "Receivable"
+msgstr "A cobrar"
+
+#. module: account_tax_balance
+#: selection:account.move,move_type:0
+msgid "Receivable refund"
+msgstr "Devoluciones a pagar"
+
+#. module: account_tax_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.view_tax_search_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.view_tax_tree_balance
+msgid "Short Name"
+msgstr "Nombre corto"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_wizard_open_tax_balances_target_move
+msgid "Target Moves"
+msgstr "Movimientos destino"
+
+#. module: account_tax_balance
+#: model:ir.model,name:account_tax_balance.model_account_tax
+msgid "Tax"
+msgstr "Impuesto"
+
+#. module: account_tax_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.view_tax_search_balance
+msgid "Tax Group"
+msgstr "Grupo del impuesto"
+
+#. module: account_tax_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.view_tax_search_balance
+msgid "Tax Scope"
+msgstr "Uso del impuesto"
+
+#. module: account_tax_balance
+#: model:ir.actions.act_window,name:account_tax_balance.action_open_tax_balances
+#: model:ir.actions.act_window,name:account_tax_balance.action_tax_balances_tree
+#: model:ir.ui.menu,name:account_tax_balance.menu_action_open_tax_balances
+#: model:ir.ui.view,arch_db:account_tax_balance.wizard_open_tax_balances
+msgid "Taxes Balance"
+msgstr "Tabla de impuestos"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_wizard_open_tax_balances_to_date
+msgid "To date"
+msgstr "Hasta"
+
+#. module: account_tax_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.view_tax_tree_balance
+msgid "Total"
+msgstr "Total"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_account_tax_balance
+msgid "Total Balance"
+msgstr "Total cuota"
+
+#. module: account_tax_balance
+#: model:ir.model.fields,field_description:account_tax_balance.field_account_tax_base_balance
+msgid "Total Base Balance"
+msgstr "Total base imponible"
+
+#. module: account_tax_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.view_tax_tree_balance
+msgid "View base lines"
+msgstr "Ver líneas de base imponible"
+
+#. module: account_tax_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.view_tax_tree_balance
+msgid "View base refund lines"
+msgstr "Ver líneas de base imponible de devoluciones"
+
+#. module: account_tax_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.view_tax_tree_balance
+msgid "View base regular lines"
+msgstr "Ver líneas de base imponible de operaciones corrientes"
+
+#. module: account_tax_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.view_tax_tree_balance
+msgid "View tax lines"
+msgstr "Ver líneas de cuota"
+
+#. module: account_tax_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.view_tax_tree_balance
+msgid "View tax refund lines"
+msgstr "Ver líneas de cuota de devoluciones"
+
+#. module: account_tax_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.view_tax_tree_balance
+msgid "View tax regular lines"
+msgstr "Ver líneas de cuota de operaciones corrientes"
+
+#. module: account_tax_balance
+#: model:ir.ui.view,arch_db:account_tax_balance.wizard_open_tax_balances
+msgid "or"
+msgstr "o"
+
+#. module: account_tax_balance
+#: model:ir.model,name:account_tax_balance.model_wizard_open_tax_balances
+msgid "wizard.open.tax.balances"
+msgstr "wizard.open.tax.balances"

--- a/account_tax_balance/models/__init__.py
+++ b/account_tax_balance/models/__init__.py
@@ -2,4 +2,5 @@
 # © 2016 Lorenzo Battistini - Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import account_move
 from . import account_tax

--- a/account_tax_balance/models/account_move.py
+++ b/account_tax_balance/models/account_move.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# © 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models, fields, api
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    move_type = fields.Selection(
+        string="Move type", selection=[
+            ('other', 'Other'),
+            ('liquidity', 'Liquidity'),
+            ('receivable', 'Receivable'),
+            ('receivable_refund', 'Receivable refund'),
+            ('payable', 'Payable'),
+            ('payable_refund', 'Payable refund'),
+        ], compute='_compute_move_type', store=True, readonly=True)
+
+    @api.multi
+    @api.depends('line_ids.account_id.internal_type', 'line_ids.balance')
+    def _compute_move_type(self):
+        def _balance_get(line_ids, internal_type):
+            return sum(line_ids.filtered(
+                lambda x: x.account_id.internal_type == internal_type).mapped(
+                    'balance'))
+
+        for move in self:
+            internal_types = move.line_ids.mapped('account_id.internal_type')
+            if 'liquidity' in internal_types:
+                move.move_type = 'liquidity'
+            elif 'payable' in internal_types:
+                balance = _balance_get(move.line_ids, 'payable')
+                move.move_type = (
+                    'payable' if balance < 0 else 'payable_refund')
+            elif 'receivable' in internal_types:
+                balance = _balance_get(move.line_ids, 'receivable')
+                move.move_type = (
+                    'receivable' if balance > 0 else 'receivable_refund')
+            else:
+                move.move_type = 'other'

--- a/account_tax_balance/models/account_tax.py
+++ b/account_tax_balance/models/account_tax.py
@@ -24,7 +24,7 @@ class AccountTax(models.Model):
         search='_search_base_balance_regular')
     balance_refund = fields.Float(
         string="Balance Refund", compute="_compute_balance",
-        search='_search_base_refund')
+        search='_search_balance_refund')
     base_balance_refund = fields.Float(
         string="Base Balance Refund", compute="_compute_balance",
         search='_search_base_balance_refund')

--- a/account_tax_balance/models/account_tax.py
+++ b/account_tax_balance/models/account_tax.py
@@ -1,16 +1,68 @@
 # -*- coding: utf-8 -*-
 # © 2016 Lorenzo Battistini - Agile Business Group
+# © 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp import models, fields, api
+from openerp.tools.safe_eval import safe_eval
 
 
 class AccountTax(models.Model):
     _inherit = 'account.tax'
 
-    balance = fields.Float(string="Balance", compute="_compute_balance")
+    balance = fields.Float(
+        string="Total Balance", compute="_compute_balance",
+        search='_search_balance')
     base_balance = fields.Float(
-        string="Base Balance", compute="_compute_balance")
+        string="Total Base Balance", compute="_compute_balance",
+        search='_search_base_balance')
+    balance_regular = fields.Float(
+        string="Balance", compute="_compute_balance",
+        search='_search_balance_regular')
+    base_balance_regular = fields.Float(
+        string="Base Balance", compute="_compute_balance",
+        search='_search_base_balance_regular')
+    balance_refund = fields.Float(
+        string="Balance Refund", compute="_compute_balance",
+        search='_search_base_refund')
+    base_balance_refund = fields.Float(
+        string="Base Balance Refund", compute="_compute_balance",
+        search='_search_base_balance_refund')
+
+    def _search_balance_field(self, field, operator, value):
+        operators = {'>', '<', '>=', '<=', '!=', '=', '<>'}
+        fields = {
+            'balance', 'base_balance', 'balance_regular',
+            'base_balance_regular', 'balance_refund', 'base_balance_refund',
+        }
+        domain = []
+        if operator in operators and field in fields:
+            value = float(value) if value else 0
+            taxes = self.search([]).filtered(
+                lambda x: safe_eval(
+                    '%.2f %s %.2f' % (x[field], operator, value)))
+            domain.append(('id', 'in', taxes.ids))
+        return domain
+
+    def _search_balance(self, operator, value):
+        return self._search_balance_field('balance', operator, value)
+
+    def _search_base_balance(self, operator, value):
+        return self._search_balance_field('base_balance', operator, value)
+
+    def _search_balance_regular(self, operator, value):
+        return self._search_balance_field('balance_regular', operator, value)
+
+    def _search_base_balance_regular(self, operator, value):
+        return self._search_balance_field(
+            'base_balance_regular', operator, value)
+
+    def _search_balance_refund(self, operator, value):
+        return self._search_balance_field('balance_refund', operator, value)
+
+    def _search_base_balance_refund(self, operator, value):
+        return self._search_balance_field(
+            'base_balance_refund', operator, value)
 
     def get_context_values(self):
         context = self.env.context
@@ -23,8 +75,19 @@ class AccountTax(models.Model):
 
     def _compute_balance(self):
         for tax in self:
-            tax.balance = tax.compute_balance(tax_or_base='tax')
-            tax.base_balance = tax.compute_balance(tax_or_base='base')
+            tax.balance_regular = tax.compute_balance(tax_or_base='tax')
+            tax.base_balance_regular = tax.compute_balance(tax_or_base='base')
+            tax.balance_refund = tax.compute_balance(
+                tax_or_base='tax', refund=True)
+            tax.base_balance_refund = tax.compute_balance(
+                tax_or_base='base', refund=True)
+            tax.balance = tax.balance_regular + tax.balance_refund
+            tax.base_balance = (
+                tax.base_balance_regular + tax.base_balance_refund)
+
+    def get_target_type_list(self, refund=False):
+        return ['receivable_refund', 'payable_refund'] if refund else \
+               ['receivable', 'payable']
 
     def get_target_state_list(self, target_move="posted"):
         if target_move == 'posted':
@@ -42,43 +105,49 @@ class AccountTax(models.Model):
             ('company_id', '=', company_id),
         ]
 
-    def compute_balance(self, tax_or_base='tax'):
+    def compute_balance(self, tax_or_base='tax', refund=False):
         self.ensure_one()
-        move_lines = self.get_move_lines_domain(tax_or_base=tax_or_base)
+        move_lines = self.get_move_lines_domain(
+            tax_or_base=tax_or_base, refund=refund)
         # balance is debit - credit whereas on tax return you want to see what
         # vat has to be paid so:
         # VAT on sales (credit) - VAT on purchases (debit).
         total = -sum([l.balance for l in move_lines])
         return total
 
-    def get_balance_domain(self, state_list):
+    def get_balance_domain(self, state_list, type_list):
         return [
+            ('move_id.move_type', 'in', type_list),
             ('move_id.state', 'in', state_list),
             ('tax_line_id', '=', self.id),
         ]
 
-    def get_base_balance_domain(self, state_list):
+    def get_base_balance_domain(self, state_list, type_list):
         return [
+            ('move_id.move_type', 'in', type_list),
             ('move_id.state', 'in', state_list),
             ('tax_ids', 'in', self.id),
         ]
 
-    def get_move_lines_domain(self, tax_or_base='tax'):
+    def get_move_lines_domain(self, tax_or_base='tax', refund=False):
         move_line_model = self.env['account.move.line']
         from_date, to_date, company_id, target_move = self.get_context_values()
         state_list = self.get_target_state_list(target_move)
+        type_list = self.get_target_type_list(refund)
         domain = self.get_move_line_partial_domain(
             from_date, to_date, company_id)
         balance_domain = []
         if tax_or_base == 'tax':
-            balance_domain = self.get_balance_domain(state_list)
+            balance_domain = self.get_balance_domain(state_list, type_list)
         elif tax_or_base == 'base':
-            balance_domain = self.get_base_balance_domain(state_list)
+            balance_domain = self.get_base_balance_domain(
+                state_list, type_list)
         domain.extend(balance_domain)
         return move_line_model.search(domain)
 
-    def get_lines_action(self, tax_or_base='tax'):
-        move_lines = self.get_move_lines_domain(tax_or_base=tax_or_base)
+    def get_lines_action(self, tax_or_base='tax', refund=False):
+        move_lines = self.get_move_lines_domain(
+            tax_or_base=tax_or_base, refund=refund)
         move_line_ids = [l.id for l in move_lines]
         action = self.env.ref('account.action_account_moves_all_tree')
         vals = action.read()[0]
@@ -95,3 +164,13 @@ class AccountTax(models.Model):
     def view_base_lines(self):
         self.ensure_one()
         return self.get_lines_action(tax_or_base='base')
+
+    @api.multi
+    def view_tax_refund_lines(self):
+        self.ensure_one()
+        return self.get_lines_action(tax_or_base='tax', refund=True)
+
+    @api.multi
+    def view_base_refund_lines(self):
+        self.ensure_one()
+        return self.get_lines_action(tax_or_base='base', refund=True)

--- a/account_tax_balance/views/account_move_view.xml
+++ b/account_tax_balance/views/account_move_view.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+
+<record id="view_move_tree" model="ir.ui.view">
+    <field name="name">Add move type column</field>
+    <field name="model">account.move</field>
+    <field name="inherit_id" ref="account.view_move_tree"/>
+    <field name="arch" type="xml">
+        <field name="state" position="after">
+            <field name="move_type"/>
+        </field>
+    </field>
+</record>
+
+<record id="view_move_form" model="ir.ui.view">
+    <field name="name">Add move type field</field>
+    <field name="model">account.move</field>
+    <field name="inherit_id" ref="account.view_move_form"/>
+    <field name="arch" type="xml">
+        <field name="ref" position="after">
+            <field name="move_type"/>
+        </field>
+    </field>
+</record>
+
+<record id="view_account_move_filter" model="ir.ui.view">
+    <field name="name">Add move type group by</field>
+    <field name="model">account.move</field>
+    <field name="inherit_id" ref="account.view_account_move_filter"/>
+    <field name="arch" type="xml">
+        <group expand="0" position="inside">
+            <filter string="Move type" domain="[]" context="{'group_by':'move_type'}"/>
+        </group>
+    </field>
+</record>
+
+</odoo>

--- a/account_tax_balance/views/account_tax_view.xml
+++ b/account_tax_balance/views/account_tax_view.xml
@@ -61,9 +61,9 @@
     <field name="view_type">form</field>
     <field name="view_mode">tree</field>
     <field name="domain">[
-        '|', '|', ('base_balance', '>', 0), ('base_balance_regular', '>', 0),
-        '|', '|', ('base_balance_refund', '>', 0), ('balance', '>', 0),
-        '|', ('balance_regular', '>', 0), ('balance_refund', '>', 0)]</field>
+        '|', '|', ('base_balance', '!=', 0), ('base_balance_regular', '!=', 0),
+        '|', '|', ('base_balance_refund', '!=', 0), ('balance', '!=', 0),
+        '|', ('balance_regular', '!=', 0), ('balance_refund', '!=', 0)]</field>
     <field name="view_id" ref="view_tax_tree_balance"/>
     <field name="search_view_id" ref="view_tax_search_balance"/>
 </record>

--- a/account_tax_balance/views/account_tax_view.xml
+++ b/account_tax_balance/views/account_tax_view.xml
@@ -1,49 +1,64 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data>
+<!-- Copyright 2016 Lorenzo Battistini - Agile Business Group
+     Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
 
-        <record id="view_tax_tree_balance" model="ir.ui.view">
-            <field name="name">account.tax.tree.balance</field>
-            <field name="model">account.tax</field>
-            <field eval="100" name="priority"/>
-            <field name="arch" type="xml">
-                <tree string="Account Tax" create="false" delete="false">
-                    <field name="name"/>
-                    <field name="description" string="Short Name"/>
-                    <field name="account_id"/>
-                    <field name="balance" sum="Total"></field>
-                    <field name="base_balance" sum="Base Total"></field>
-                    <button type="object" name="view_tax_lines" string="View tax lines" icon="gtk-find"></button>
-                    <button type="object" name="view_base_lines" string="View base lines" icon="gtk-copy"></button>
-                </tree>
-            </field>
-         </record>
-        <record id="view_tax_search_balance" model="ir.ui.view">
-            <field name="name">account.tax.search.balance</field>
-            <field name="model">account.tax</field>
-            <field eval="100" name="priority"/>
-            <field name="arch" type="xml">
-                <search string="Account Tax">
-                    <field name="name"/>
-                    <field name="tag_ids"/>
-                    <field name="description" string="Short Name"/>
-                    <field name="type_tax_use"/>
-                    <field name="account_id"/>
-                    <group expand="0" string="Group By">
-                        <filter string="Tax Group" domain="[]" context="{'group_by':'tax_group_id'}"/>
-                        <filter string="Tax Scope" domain="[]" context="{'group_by':'type_tax_use'}"/>
-                        <filter string="Account" domain="[]" context="{'group_by':'account_id'}"/>
-                    </group>
-                </search>
-            </field>
-         </record>
-        <record id="action_tax_balances_tree" model="ir.actions.act_window">
-            <field name="name">Taxes Balance</field>
-            <field name="res_model">account.tax</field>
-            <field name="view_type">form</field>
-            <field name="view_mode">tree</field>
-            <field name="view_id" ref="view_tax_tree_balance"/>
-            <field name="search_view_id" ref="view_tax_search_balance"/>
-        </record>
-    </data>
-</openerp>
+<record id="view_tax_tree_balance" model="ir.ui.view">
+    <field name="name">account.tax.tree.balance</field>
+    <field name="model">account.tax</field>
+    <field eval="100" name="priority"/>
+    <field name="arch" type="xml">
+        <tree string="Account Tax" create="false" delete="false">
+            <field name="name"/>
+            <field name="description" string="Short Name"/>
+            <field name="account_id"/>
+            <field name="balance_regular" sum="Total"/>
+            <button type="object" name="view_tax_lines"
+                    string="View tax lines" icon="fa-search-plus"/>
+            <field name="base_balance_regular" sum="Base Total"/>
+            <button type="object" name="view_base_lines"
+                    string="View base lines" icon="fa-search-plus"/>
+            <field name="balance_refund" sum="Total"/>
+            <button type="object" name="view_tax_refund_lines"
+                    string="View tax refund lines" icon="fa-search-plus"/>
+            <field name="base_balance_refund" sum="Base Total"/>
+            <button type="object" name="view_base_refund_lines"
+                    string="View base refund lines" icon="fa-search-plus"/>
+            <field name="balance" sum="Total"/>
+            <field name="base_balance" sum="Base Total"/>
+        </tree>
+    </field>
+</record>
+
+<record id="view_tax_search_balance" model="ir.ui.view">
+    <field name="name">account.tax.search.balance</field>
+    <field name="model">account.tax</field>
+    <field eval="100" name="priority"/>
+    <field name="arch" type="xml">
+        <search string="Account Tax">
+            <field name="name"/>
+            <field name="tag_ids"/>
+            <field name="description" string="Short Name"/>
+            <field name="type_tax_use"/>
+            <field name="account_id"/>
+            <group expand="0" string="Group By">
+                <filter string="Tax Group" domain="[]" context="{'group_by':'tax_group_id'}"/>
+                <filter string="Tax Scope" domain="[]" context="{'group_by':'type_tax_use'}"/>
+                <filter string="Account" domain="[]" context="{'group_by':'account_id'}"/>
+            </group>
+        </search>
+    </field>
+ </record>
+
+<record id="action_tax_balances_tree" model="ir.actions.act_window">
+    <field name="name">Taxes Balance</field>
+    <field name="res_model">account.tax</field>
+    <field name="view_type">form</field>
+    <field name="view_mode">tree</field>
+    <field name="domain">['|', ('base_balance_regular', '>', 0), ('base_balance_refund', '>', 0)]</field>
+    <field name="view_id" ref="view_tax_tree_balance"/>
+    <field name="search_view_id" ref="view_tax_search_balance"/>
+</record>
+
+</odoo>

--- a/account_tax_balance/views/account_tax_view.xml
+++ b/account_tax_balance/views/account_tax_view.xml
@@ -60,7 +60,10 @@
     <field name="res_model">account.tax</field>
     <field name="view_type">form</field>
     <field name="view_mode">tree</field>
-    <field name="domain">['|', ('base_balance_regular', '>', 0), ('base_balance_refund', '>', 0)]</field>
+    <field name="domain">[
+        '|', '|', ('base_balance', '>', 0), ('base_balance_regular', '>', 0),
+        '|', '|', ('base_balance_refund', '>', 0), ('balance', '>', 0),
+        '|', ('balance_regular', '>', 0), ('balance_refund', '>', 0)]</field>
     <field name="view_id" ref="view_tax_tree_balance"/>
     <field name="search_view_id" ref="view_tax_search_balance"/>
 </record>

--- a/account_tax_balance/views/account_tax_view.xml
+++ b/account_tax_balance/views/account_tax_view.xml
@@ -14,11 +14,11 @@
             <field name="description" string="Short Name"/>
             <field name="account_id"/>
             <field name="balance_regular" sum="Total"/>
-            <button type="object" name="view_tax_lines"
-                    string="View tax lines" icon="fa-search-plus"/>
+            <button type="object" name="view_tax_regular_lines"
+                    string="View tax regular lines" icon="fa-search-plus"/>
             <field name="base_balance_regular" sum="Base Total"/>
-            <button type="object" name="view_base_lines"
-                    string="View base lines" icon="fa-search-plus"/>
+            <button type="object" name="view_base_regular_lines"
+                    string="View base regular lines" icon="fa-search-plus"/>
             <field name="balance_refund" sum="Total"/>
             <button type="object" name="view_tax_refund_lines"
                     string="View tax refund lines" icon="fa-search-plus"/>
@@ -26,7 +26,11 @@
             <button type="object" name="view_base_refund_lines"
                     string="View base refund lines" icon="fa-search-plus"/>
             <field name="balance" sum="Total"/>
+            <button type="object" name="view_tax_lines"
+                    string="View tax lines" icon="fa-search-plus"/>
             <field name="base_balance" sum="Base Total"/>
+            <button type="object" name="view_base_lines"
+                    string="View base lines" icon="fa-search-plus"/>
         </tree>
     </field>
 </record>

--- a/account_tax_balance/wizard/open_tax_balances_view.xml
+++ b/account_tax_balance/wizard/open_tax_balances_view.xml
@@ -1,40 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data>
-        <record id="wizard_open_tax_balances" model="ir.ui.view">
-            <field name="name">wizard_open_tax_balances</field>
-            <field name="model">wizard.open.tax.balances</field>
-            <field name="arch" type="xml">
-                <form string="Taxes Balance">
-                    <group>
-                        <field name="company_id"/>
-                        <field name="date_range_id"/>
-                        <field name="from_date"></field>
-                        <field name="to_date"></field>
-                        <field name="target_move"></field>
-                    </group>
-                    <footer>
-                        <button string="Open Taxes" name="open_taxes" type="object" class="oe_highlight"/>
-                        or
-                        <button string="Cancel" class="oe_link" special="cancel"/>
-                    </footer>
-                </form>
-            </field>
-         </record>
+<!-- Copyright 2016 Lorenzo Battistini - Agile Business Group
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
 
-        <record id="action_open_tax_balances" model="ir.actions.act_window">
-            <field name="name">Taxes Balance</field>
-            <field name="res_model">wizard.open.tax.balances</field>
-            <field name="view_type">form</field>
-            <field name="view_mode">form</field>
-            <field name="view_id" ref="wizard_open_tax_balances"/>
-            <field name="target">new</field>
-        </record>
+<record id="wizard_open_tax_balances" model="ir.ui.view">
+    <field name="name">wizard_open_tax_balances</field>
+    <field name="model">wizard.open.tax.balances</field>
+    <field name="arch" type="xml">
+        <form string="Taxes Balance">
+            <group>
+                <field name="company_id"/>
+                <field name="date_range_id"/>
+                <field name="from_date"></field>
+                <field name="to_date"></field>
+                <field name="target_move"></field>
+            </group>
+            <footer>
+                <button string="Open Taxes" name="open_taxes" type="object" class="oe_highlight"/>
+                or
+                <button string="Cancel" class="oe_link" special="cancel"/>
+            </footer>
+        </form>
+    </field>
+ </record>
 
-        <menuitem
-            action="action_open_tax_balances"
-            id="menu_action_open_tax_balances"
-            parent="account.menu_finance_reports"
-            groups="account.group_account_user,account.group_account_manager"></menuitem>
-    </data>
-</openerp>
+<record id="action_open_tax_balances" model="ir.actions.act_window">
+    <field name="name">Taxes Balance</field>
+    <field name="res_model">wizard.open.tax.balances</field>
+    <field name="view_type">form</field>
+    <field name="view_mode">form</field>
+    <field name="view_id" ref="wizard_open_tax_balances"/>
+    <field name="target">new</field>
+</record>
+
+<menuitem
+    action="action_open_tax_balances"
+    id="menu_action_open_tax_balances"
+    parent="account.menu_finance_reports"
+    groups="account.group_account_user,account.group_account_manager"/>
+
+</odoo>


### PR DESCRIPTION
Improvements proposed in https://github.com/OCA/account-financial-reporting/pull/190#issuecomment-255330481
- Separate tax/base amount from normal and refund oprations
- Search by tax/base non-stored fields
- Use font-awesome icons
